### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.all.order('created_at DESC')
   end
@@ -35,6 +35,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    @item.destroy
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_redirect, only: [:edit, :update, :destroy]
+
   def index
     @items = Item.all.order('created_at DESC')
   end
@@ -22,7 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path unless @item.user_id == current_user.id
   end
 
   def update
@@ -31,7 +32,6 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
-    redirect_to root_path unless @item.user_id == current_user.id
   end
 
   def destroy
@@ -48,5 +48,9 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def set_redirect
+    redirect_to root_path unless @item.user_id == current_user.id
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   resources :items do
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :items do
 end


### PR DESCRIPTION
# What
商品の削除機能の追加。

# Why
商品出品後に商品の削除をできるようにする為。
　　
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画https://gyazo.com/3f26397ab8add29f485810dc771e307f